### PR TITLE
Support browser storage outside Chrome (fix keybinds)

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -1,10 +1,12 @@
+const storage = (typeof browser === 'undefined') ? chrome.storage.local : browser.storage.local;
 var muted = false;
 var volumeState = 0;
 var actualVolume = 0;
 var mouseX;
-// Using localStorage as a fallback for chrome.storage.local
+
+// Using localStorage as a fallback for browser/chrome.storage.local
 var keybinds = JSON.parse(localStorage.getItem("yt-keybinds"));
-chrome.storage.local.get(["keybinds"])
+storage.get(["keybinds"])
 .then((result) => {
   if (result.keybinds) {
     if (result.keybinds !== keybinds) localStorage.setItem("yt-keybinds", JSON.stringify(result.keybinds));

--- a/content-script.js
+++ b/content-script.js
@@ -2,7 +2,6 @@ const storage = (typeof browser === 'undefined') ? chrome.storage.local : browse
 var muted = false;
 var volumeState = 0;
 var actualVolume = 0;
-var mouseX;
 
 // Using localStorage as a fallback for browser/chrome.storage.local
 var keybinds = JSON.parse(localStorage.getItem("yt-keybinds"));
@@ -23,6 +22,7 @@ document.addEventListener("keydown", (data) => {
     "#shorts-player > div.html5-video-container > video"
   );
   if (!ytShorts) return;
+  if (!keybinds) keybinds = {'Seek Backward': 'j','Seek Forward': 'l','Decrease Speed': 'u','Reset Speed': 'i','Increase Speed': 'o','Decrease Volume': '-','Increase Volume': '+','Toggle Mute': 'm'};
   const key = data.key.toLowerCase();
   let command;
   for (const [cmd, keybind] of Object.entries(keybinds)) if (key === keybind) command = cmd;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Better YouTube Shorts",
     "description": "Playback, volume controls (with custom keybinds), timestamp, and progress bar seeking on YouTube Shorts.",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "manifest_version": 3,
     "permissions": ["storage"],
     "action": {

--- a/popup.js
+++ b/popup.js
@@ -87,7 +87,7 @@ keybindInput.addEventListener('keydown', (event) => {
     document.getElementById(keybindState+'-span').textContent = keybind;
     currentKeybinds[keybindState] = keybind;
     currentKeybindArray = Object.values(currentKeybinds);
-    browser.storage.local.set({ 'keybinds' : currentKeybinds })
+    storage.set({ 'keybinds' : currentKeybinds })
     .then(() => {
         keybindInput.value = "";
         closeBtn.click(); 

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,5 @@
-const storage = (typeof browser === 'undefined') ? chrome.storage.local : browser.storage.local;
-const version = browser.runtime.getManifest().version;
+const browserObj = (typeof browser === 'undefined') ? chrome : browser;
+const version = browserObj.runtime.getManifest().version;
 document.getElementById('version').textContent = version;
 
 const modal = document.getElementById("edit-modal");
@@ -25,7 +25,7 @@ let currentKeybindArray = [];
 let keybindState = '';
 
 // Get keybinds from storage
-storage.get(['keybinds'])
+browserObj.storage.local.get(['keybinds'])
 .then((result) => {
     let updatedkeybinds = result['keybinds'];
     if (updatedkeybinds) {
@@ -54,7 +54,7 @@ resetBtn.onclick = () => {
     currentKeybindArray = Object.values(currentKeybinds);
     for (const [command, keybind] of Object.entries(defaultKeybinds)) {
         document.getElementById(command+'-span').textContent = keybind;
-        storage.set({ 'keybinds' : defaultKeybinds });
+        browserObj.storage.local.set({ 'keybinds' : defaultKeybinds });
     }
 }
 
@@ -87,7 +87,7 @@ keybindInput.addEventListener('keydown', (event) => {
     document.getElementById(keybindState+'-span').textContent = keybind;
     currentKeybinds[keybindState] = keybind;
     currentKeybindArray = Object.values(currentKeybinds);
-    storage.set({ 'keybinds' : currentKeybinds })
+    browserObj.storage.local.set({ 'keybinds' : currentKeybinds })
     .then(() => {
         keybindInput.value = "";
         closeBtn.click(); 

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,5 @@
-const version = chrome.runtime.getManifest().version;
+const storage = (typeof browser === 'undefined') ? chrome.storage.local : browser.storage.local;
+const version = browser.runtime.getManifest().version;
 document.getElementById('version').textContent = version;
 
 const modal = document.getElementById("edit-modal");
@@ -7,7 +8,7 @@ const editBtnList = document.querySelectorAll(".edit-btn");
 const closeBtn = document.querySelector(".close-btn");
 const keybindInput = document.getElementById("keybind-input");
 let modalTitleSpan = document.getElementById("modal-title-span");
-let invalidKeybinds = ['backspace', 'enter', 'escape', 'tab', ' ', 'space', 'pageUp', 'pagedown', 'arrowup', 'arrowdown', 'printscreen', 'meta'];
+let invalidKeybinds = ['backspace', 'enter', 'escape', 'tab', ' ', 'space', 'pageup', 'pagedown', 'arrowup', 'arrowdown', 'printscreen', 'meta'];
 
 const defaultKeybinds = {
     'Seek Backward': 'j',
@@ -24,7 +25,7 @@ let currentKeybindArray = [];
 let keybindState = '';
 
 // Get keybinds from storage
-chrome.storage.local.get(['keybinds'])
+storage.get(['keybinds'])
 .then((result) => {
     let updatedkeybinds = result['keybinds'];
     if (updatedkeybinds) {
@@ -53,7 +54,7 @@ resetBtn.onclick = () => {
     currentKeybindArray = Object.values(currentKeybinds);
     for (const [command, keybind] of Object.entries(defaultKeybinds)) {
         document.getElementById(command+'-span').textContent = keybind;
-        chrome.storage.local.set({ 'keybinds' : defaultKeybinds });
+        storage.set({ 'keybinds' : defaultKeybinds });
     }
 }
 
@@ -86,7 +87,7 @@ keybindInput.addEventListener('keydown', (event) => {
     document.getElementById(keybindState+'-span').textContent = keybind;
     currentKeybinds[keybindState] = keybind;
     currentKeybindArray = Object.values(currentKeybinds);
-    chrome.storage.local.set({ 'keybinds' : currentKeybinds })
+    browser.storage.local.set({ 'keybinds' : currentKeybinds })
     .then(() => {
         keybindInput.value = "";
         closeBtn.click(); 


### PR DESCRIPTION
This should fix keybinds outside of Chrome. Tested on Firefox. Not sure about Edge/Opera/etc. Added default keybinds in case browser storage still doesn't work somehow