### PR TITLE
changed j and l to arrrowleft and arrowright

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can control your YouTube shorts with playback controls just like a normal Yo
 * Firefox Add-on: https://addons.mozilla.org/en-US/firefox/addon/better-youtube-shorts
 
 ## Features
-* Seeking 5 seconds backward and forward (default: J and L)
+* Seeking 5 seconds backward and forward (default: ArrowLeft and ArrowRight)
 * Seeking a precise timestamp in the progress bar
 * Decrease and increase playback rate (default: U and O)
 * Revert to normal speed with I or by clicking the button

--- a/content-script.js
+++ b/content-script.js
@@ -22,7 +22,7 @@ document.addEventListener("keydown", (data) => {
     "#shorts-player > div.html5-video-container > video"
   );
   if (!ytShorts) return;
-  if (!keybinds) keybinds = {'Seek Backward': 'j','Seek Forward': 'l','Decrease Speed': 'u','Reset Speed': 'i','Increase Speed': 'o','Decrease Volume': '-','Increase Volume': '+','Toggle Mute': 'm'};
+  if (!keybinds) keybinds = {'Seek Backward': 'arrowleft','Seek Forward': 'arrowright','Decrease Speed': 'u','Reset Speed': 'i','Increase Speed': 'o','Decrease Volume': '-','Increase Volume': '+','Toggle Mute': 'm'};
   const key = data.key.toLowerCase();
   let command;
   for (const [cmd, keybind] of Object.entries(keybinds)) if (key === keybind) command = cmd;

--- a/popup.html
+++ b/popup.html
@@ -21,7 +21,7 @@
       <td>Seek backward <span style="font-style: italic;">(-5s)</span></td>
       <td>
         <div class="keybind-wrapper">
-          <span id="Seek Backward-span" class="keybind-span">J</span>
+          <span id="Seek Backward-span" class="keybind-span">ArrowLeft</span>
           <div id="Seek Backward" class="edit-btn">
             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px"><g id="pencil-svg" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path d="M21.707,5.565,18.435,2.293a1,1,0,0,0-1.414,0L3.93,15.384a.991.991,0,0,0-.242.39l-1.636,4.91A1,1,0,0,0,3,22a.987.987,0,0,0,.316-.052l4.91-1.636a.991.991,0,0,0,.39-.242L21.707,6.979A1,1,0,0,0,21.707,5.565ZM7.369,18.489l-2.788.93.93-2.788,8.943-8.944,1.859,1.859ZM17.728,8.132l-1.86-1.86,1.86-1.858,1.858,1.858Z"></path></g></svg>
           </div>
@@ -32,7 +32,7 @@
       <td>Seek forward <span style="font-style: italic;">(+5s)</span></td>
       <td>
         <div class="keybind-wrapper">
-          <span id="Seek Forward-span" class="keybind-span">L</span>
+          <span id="Seek Forward-span" class="keybind-span">ArrowRight</span>
           <div id="Seek Forward" class="edit-btn">
             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px"><g id="pencil-svg" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path d="M21.707,5.565,18.435,2.293a1,1,0,0,0-1.414,0L3.93,15.384a.991.991,0,0,0-.242.39l-1.636,4.91A1,1,0,0,0,3,22a.987.987,0,0,0,.316-.052l4.91-1.636a.991.991,0,0,0,.39-.242L21.707,6.979A1,1,0,0,0,21.707,5.565ZM7.369,18.489l-2.788.93.93-2.788,8.943-8.944,1.859,1.859ZM17.728,8.132l-1.86-1.86,1.86-1.858,1.858,1.858Z"></path></g></svg>
           </div>

--- a/popup.js
+++ b/popup.js
@@ -11,8 +11,8 @@ let modalTitleSpan = document.getElementById("modal-title-span");
 let invalidKeybinds = ['backspace', 'enter', 'escape', 'tab', ' ', 'space', 'pageup', 'pagedown', 'arrowup', 'arrowdown', 'printscreen', 'meta'];
 
 const defaultKeybinds = {
-    'Seek Backward': 'j',
-    'Seek Forward': 'l',
+    'Seek Backward': 'arrowleft',
+    'Seek Forward': 'arrowright',
     'Decrease Speed': 'u',
     'Reset Speed': 'i',
     'Increase Speed': 'o',


### PR DESCRIPTION
Left and right arrows are far more intuitive defaults than j and l since arrowup and arrowdown can be used in shorts to navigate to previous and next shorts it only makes sense for left and right to seek backward and forward.