### PR TITLE
resolves #3 - Added auto skip for shorts with low likes

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -256,3 +256,44 @@ a {
 	outline: none !important;
 	box-shadow: 0 0 3px #00000020;
 }
+
+
+
+.extra_options--row
+{
+  display: grid;
+  grid-template-columns: 5fr 1fr;
+  text-wrap: balance;
+  margin-bottom: 16px;
+}
+
+.extra_options--row:last-child()
+{
+  margin-bottom: 0;
+}
+
+
+.extra_options--row input[type="number"],
+.extra_options--row input[type="text"]
+{
+  outline: none;
+  border: 1px var( --bg-secondary-hover-color ) solid;
+  background: var( --bg-secondary-hover-color );
+  color: var(--text-primary-color);
+  padding: 0 1rem;
+  border-radius: 100vh;
+  width: 5rem;
+}
+.extra_options--row input[type="number"]:focus,
+.extra_options--row input[type="text"]:focus
+{
+  border: 2px var(--yt-brand-color) solid;
+}
+
+
+.extra_options--row input[type="checkbox"],
+.extra_options--row input[type="radio"],
+.extra_options--row input[type="range"]
+{
+  accent-color: var(--yt-brand-color);
+}

--- a/popup.css
+++ b/popup.css
@@ -297,3 +297,14 @@ a {
 {
   accent-color: var(--yt-brand-color);
 }
+
+.extra_options--row input[type="number"]::-webkit-outer-spin-button,
+.extra_options--row input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+.extra_options--row input[type="number"] {
+  -moz-appearance: textfield;
+}

--- a/popup.html
+++ b/popup.html
@@ -232,11 +232,11 @@
   <h3 class="prevent-selection" style="text-align: center;margin:5px 0px;">Extra Options</h3>
   <div id="extra_options">
     <div class="extra_options--row">
-      <label for="skip-bad-shorts">Automatically Skip Shorts with Low Likes?</label>
+      <label for="skip-bad-shorts">Automatically Skip Shorts with fewer likes?</label>
       <input type="checkbox" id="extra_options_skip_enabled" name="skip-bad-shorts">
     </div>
     <div class="extra_options--row">
-      <label for="skip-bad-shorts">Skip shorts with fewer than this many likes:</label>
+      <label for="skip-bad-shorts">Skip shorts with fewer than this many likes</label>
       <input type="number" id="extra_options_skip_threshold" name="skip-bad-shorts-threshold" min=0>
     </div>
   </div>

--- a/popup.html
+++ b/popup.html
@@ -229,9 +229,21 @@
       </td>
     </tr>
   </table>
-  <div class="footer prevent-selection">Reload the page for changes to take effect.</div>
-  <div class="btn-wrapper"><span class="btn reset-btn">Reset keybinds</span><a href="https://github.com/ynshung/better-yt-shorts" target="_blank"><span class="btn">GitHub</span></a></div>
+  <h3 class="prevent-selection" style="text-align: center;margin:5px 0px;">Extra Options</h3>
+  <div id="extra_options">
+    <div class="extra_options--row">
+      <label for="skip-bad-shorts">Automatically Skip Shorts with Low Likes?</label>
+      <input type="checkbox" id="extra_options_skip_enabled" name="skip-bad-shorts">
+    </div>
+    <div class="extra_options--row">
+      <label for="skip-bad-shorts">Skip shorts with fewer than this many likes:</label>
+      <input type="number" id="extra_options_skip_threshold" name="skip-bad-shorts-threshold" min=0>
+    </div>
+  </div>
 
+  <div class="footer prevent-selection">Reload the page for changes to take effect.</div>
+  <div class="btn-wrapper"><span class="btn reset-btn">Reset keybinds</span><a href="https://github.com/ynshung/better-yt-shorts" target="_blank"><span class="btn">GitHub</span></a><span class="btn save-btn">Save</span></div>
+  
   <!-- Modal -->
   <div id="edit-modal" class="modal">
     <div class="modal-content">

--- a/popup.js
+++ b/popup.js
@@ -7,6 +7,7 @@ const resetBtn = document.querySelector(".reset-btn");
 const editBtnList = document.querySelectorAll(".edit-btn");
 const closeBtn = document.querySelector(".close-btn");
 const keybindInput = document.getElementById("keybind-input");
+
 let modalTitleSpan = document.getElementById("modal-title-span");
 let invalidKeybinds = ['backspace', 'enter', 'escape', 'tab', ' ', 'space', 'pageup', 'pagedown', 'arrowup', 'arrowdown', 'printscreen', 'meta'];
 
@@ -22,7 +23,13 @@ const defaultKeybinds = {
     'Next Frame': ',',
     'Previous Frame': '.'
 };
+const defaultExtraOptions = {
+  skip_enabled:   false,
+  skip_threshold: 500,
+}
+
 let currentKeybinds = Object.assign({}, defaultKeybinds);
+let currentExtraOpts = Object.assign({}, defaultExtraOptions);
 let currentKeybindArray = [];
 let keybindState = '';
 
@@ -53,6 +60,23 @@ browserObj.storage.local.get(['keybinds'])
     currentKeybindArray = Object.values(currentKeybinds);
 });
 
+// Get extra options from storage
+browserObj.storage.local.get(['extraopts'])
+  .then((result) => {
+      let updatedExtraOpts = result['extraopts'];
+      if ( updatedExtraOpts ) {
+        // Set default extraopts if not exists
+        for (const [ option, value ] of Object.entries( defaultExtraOptions )) {
+          if (result.extraopts[ option ]) continue
+
+          result.extraopts[ option ] = value;
+        }
+      }
+        
+    initOptions( result.extraopts )
+
+  })
+
 // Open modal
 for (let i = 0; i < editBtnList.length; i++) {
     editBtnList[i].onclick = function() {
@@ -62,6 +86,12 @@ for (let i = 0; i < editBtnList.length; i++) {
         modalTitleSpan.textContent = this.id;
         keybindState = this.id;
     }
+}
+
+document.querySelector( ".save-btn" ).onclick = () => {
+  let newOptions = getUpdatedOptions( currentExtraOpts )
+  browserObj.storage.local.set({ 'extraopts' : newOptions })
+  alert( "Saved Changes!" )
 }
 
 resetBtn.onclick = () => {
@@ -85,7 +115,6 @@ window.onclick = (event) => {
 keybindInput.addEventListener('keydown', (event) => {
     event.preventDefault();
     var keybind = event.key.toLowerCase();
-    console.log(keybind);
     if (invalidKeybinds.includes(keybind)) {
         if (keybind === ' ') keybind = 'space';
         keybindInput.value = "";
@@ -108,3 +137,26 @@ keybindInput.addEventListener('keydown', (event) => {
         closeBtn.click(); 
     });
 });
+
+function getUpdatedOptions( updatedExtraOpts )
+{
+  // save skip toggle
+  updatedExtraOpts.skip_enabled   = document.getElementById( "extra_options_skip_enabled" ).checked
+  
+  // save skip threshold
+  updatedExtraOpts.skip_threshold = document.getElementById( "extra_options_skip_threshold" ).valueAsNumber
+
+  return updatedExtraOpts
+}
+
+function initOptions( options )
+{
+  // set skip toggle
+  document.getElementById( "extra_options_skip_enabled" ).checked = options.skip_enabled
+  
+  // set skip threshold
+  document.getElementById( "extra_options_skip_threshold" ).value = options.skip_threshold
+
+  console.log( `[Better Youtube Shorts] :: Intitialised Options` )
+  
+}


### PR DESCRIPTION
Added an additional section to the popup for "extra options".
I figured that this option would be too uncommon for it to be in the regular controls.

![image](https://github.com/ynshung/better-yt-shorts/assets/74009107/8ae1b081-4b7c-43f1-b401-e0bccce4c6f4)

There is a checkbox that enables this feature
Theres an input through which the user can set the threshold for the number of likes a post must have in order to be skipped.

Finally, theres a save button. This *could* just be done via events, but I figured thatd be far more costly - especially with the input.

potential issues:
- I havent tested on firefox (this is my first time editing extensions and i couldnt figure out how to open this in it)
- I wrote a method to convert formatted numbers like 1K to 1000. Not sure if other languages use other letters, if so, that'll need changed. (There must be a builtin for that im missing)