### PR TITLE
Resolves #53 - Fixed progress bar not showing for certain videos

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -212,6 +212,9 @@ const timer = setInterval(() => {
   var overlayList = getOverlayElement(currentId);
   var autoplayEnabled = localStorage.getItem("yt-autoplay") === "true" ? true : false;
   if (autoplayEnabled === null) autoplayEnabled = false;
+  
+  var progBarList = overlayList.children[2].children[0].children[0];
+  progBarList.removeAttribute( "hidden" )
 
   if (injectedItem.has(currentId)) {
     var currTime = Math.round(ytShorts.currentTime);
@@ -348,9 +351,6 @@ const timer = setInterval(() => {
       var progBarList = overlayList.children[2].children[0].children[0];
       var progBarBG = progBarList.children[0];
       var progBarPlayed = progBarList.children[1]; // The red part of the progress bar
-
-      // Force progress bar to be visible for sub-30s shorts
-      if (ytShorts.duration < 30) progBarList.removeAttribute("hidden"); 
 
       const timestampTooltip = document.createElement("div");
       timestampTooltip.classList.add("betterYT-timestamp-tooltip");


### PR DESCRIPTION
To fix, I just removed moved the `removeAttribute` line to be called in the `timer` interval, regardless of duration

Bit of a bodge fix, but its tested and working. A better solution would be preferable, but I have no idea why it wouldnt work the first time. Maybe video loading time issues? I consistently got the duration as NaN, but the actual video object always had a proper duration...

I wonder if its possible to have a single time callback when we know the player has definitely loaded for things like this. 