### PR TITLE
Fixes #58, more specific selector for text color

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -23,6 +23,24 @@
 	--call-to-action-color: #3978e6;
 }
 
+:where(
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  table,
+  tr,
+  td,
+  th,
+  p,
+  li,
+  span,
+){
+  color: var(--text-primary-color);
+}
+
 body {
 	font-family: 'Source Sans Pro', 'Roboto', 'Noto', 'Arial', sans-serif;
 	background: var(--bg-primary-color);


### PR DESCRIPTION
Noticed this before and forgot to fix it.

Can reproduce by refreshing the page and immediately opening the popup. Also, sometimes it works, then breaks or vice versa.

I think the issue is that the body selector isnt specific enough, so the default black will still be used sometimes.
 
This should be fixed with this PR (from my testing at least)

For #58 