### PR TITLE
Resolves #38 - Option to change seek amount

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -15,6 +15,7 @@ const defaultKeybinds = {
 const defaultExtraOptions = {
   skip_enabled:   false,
   skip_threshold: 500,
+  seek_amount: 5,
 }
 const storage = (typeof browser === 'undefined') ? chrome.storage.local : browser.storage.local;
 var muted = false;
@@ -119,11 +120,11 @@ document.addEventListener("keydown", (data) => {
   
   switch (command) {
     case "Seek Backward":
-      ytShorts.currentTime -= 5;
+      ytShorts.currentTime -= extraOptions?.seek_amount ?? defaultExtraOptions.seek_amount;
       break;
 
     case "Seek Forward":
-      ytShorts.currentTime += 5;
+      ytShorts.currentTime += extraOptions?.seek_amount ?? defaultExtraOptions.seek_amount;
       break;
 
     case "Decrease Speed":

--- a/popup.css
+++ b/popup.css
@@ -309,17 +309,19 @@ a {
 .extra_options--row input[type="text"]
 {
   outline: none;
-  border: 1px var( --bg-secondary-hover-color ) solid;
+  outline: 1px var( --bg-secondary-hover-color ) solid;
   background: var( --bg-secondary-hover-color );
   color: var(--text-primary-color);
-  padding: 0 1rem;
+  border:none;
+  padding: 0.25rem 1rem;
   border-radius: 100vh;
   width: 5rem;
+  height: fit-content;
 }
 .extra_options--row input[type="number"]:focus,
 .extra_options--row input[type="text"]:focus
 {
-  border: 2px var(--yt-brand-color) solid;
+  outline: 2px var(--yt-brand-color) solid;
 }
 
 

--- a/popup.html
+++ b/popup.html
@@ -24,6 +24,10 @@
       <label for="skip-bad-shorts">Skip shorts with fewer than this many likes:</label>
       <input type="number" id="extra_options_skip_threshold" name="skip-bad-shorts-threshold" min=0>
     </div>
+    <div class="extra_options--row">
+      <label for="seek-amount">How many seconds to seek?</label>
+      <input type="number" id="extra_options_seek_amount" name="seek-amount" min=1 max=60>
+    </div>
   </div>
 
   <div class="footer prevent-selection">Reload the page for changes to take effect.</div>

--- a/popup.js
+++ b/popup.js
@@ -50,6 +50,7 @@ const defaultKeybinds = {
 const defaultExtraOptions = {
   skip_enabled:   false,
   skip_threshold: 500,
+  seek_amount: 5,
 }
 
 // this is so that the bindings are always generated in the right order
@@ -118,6 +119,9 @@ browserObj.storage.local.get(['extraopts'])
 
         // set skip threshold
         document.getElementById( "extra_options_skip_threshold" ).value = result.extraopts.skip_threshold;
+
+        // set seek amount
+        document.getElementById( "extra_options_seek_amount" ).value = result.extraopts.seek_amount;
       } 
 
   })
@@ -196,6 +200,14 @@ document.getElementById( "extra_options_skip_threshold" ).addEventListener( "inp
   browserObj.storage.local.get(['extraopts']).then( result => {
     if (result !== null && Object.keys(result).length !== 0) currentExtraOpts = result.extraopts
     currentExtraOpts.skip_threshold = e.target.valueAsNumber;
+    browserObj.storage.local.set({ 'extraopts' : currentExtraOpts });
+  });
+});
+
+document.getElementById( "extra_options_seek_amount" ).addEventListener( "input", e => {
+  browserObj.storage.local.get(['extraopts']).then( result => {
+    if (result !== null && Object.keys(result).length !== 0) currentExtraOpts = result.extraopts
+    currentExtraOpts.seek_amount = e.target.valueAsNumber;
     browserObj.storage.local.set({ 'extraopts' : currentExtraOpts });
   });
 });


### PR DESCRIPTION
Added a new option in the Extra Options menu to change the number of seconds that seeking will skip, both forward and back

the default number of seconds will be used if options haven't been loaded from storage, or if the user hasnt set it

Styling may still need work for Firefox

for #38 

(was having issues with pushing, so ignore those other commits)