### PR TITLE
Resolves #65 - Populate with defaults if binds arent found from storage

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -85,7 +85,9 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', eve
 // Get keybinds from storage
 browserObj.storage.local.get(['keybinds'])
 .then((result) => {
+    populateKeybindsTable( defaultKeybinds ) // populate with default binds
     let updatedkeybinds = result['keybinds'];
+
     if (updatedkeybinds) {
         // Set default keybinds if not exists
         for (const [cmd, keybind] of Object.entries(defaultKeybinds)) {
@@ -95,6 +97,7 @@ browserObj.storage.local.get(['keybinds'])
         populateKeybindsTable( updatedkeybinds )
         currentKeybinds = updatedkeybinds;
     }
+    
     // Keybind array for easier checking if keybind is already in use
     currentKeybindArray = Object.values(currentKeybinds);
 });


### PR DESCRIPTION
I know the ticket is closed, but I dont know if this has been resolved. No changes were made.

I can't replicate, but I think it may have just been that the keybinds table wasnt being populated with defaults in the event that user keybinds arent loaded from storage.

It was previously only populated when
- the binds are loaded from storage
- the binds were reset
- a new bind was set

It should now populate the binds table with defaults before checking if the binds were loaded from storage. If they are loaded from storage, no problem, the defaults will be overwritten