### PR TITLE
Enhance Playback Speed Button: Toggle Between 1x and 2x

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -491,7 +491,7 @@ const timer = setInterval(() => {
       injectedSuccess = setTimer(currTime || 0, Math.round(ytShorts.duration || 0));
 
       betterYTContainer.addEventListener("click",() => {
-        ytShorts.playbackRate = 1;
+	ytShorts.playbackRate = ytShorts.playbackRate == 1 ? 2 : 1;
         setSpeed = ytShorts.playbackRate;
       });
 


### PR DESCRIPTION
## Description

This pull request addresses an issues I have with the playback speed button. In its original state, all it does is reset the playback speed to 1x if it is any other value. Thus if you want to increase playback speed, you have to use keyboard shortcuts.

## Changes Made

- Updated the eventListener to toggle playbackRate between 2x and 1x
- If playbackRate is 1x, clicking the button will toggle it to 2x. If playbackRate is any other value, clicking the button will make it 1x

## Notes
- In my opinion, this change makes the extension much more usable
- Consider also making the button a dropdown list, much like normal YouTube videos, with options such as 1.25, 1.5, 1.75, 2
- Alternatively, you could add more options to toggle between, such as adding 1.5x. This could also be a customization option that users could set up themselves