### PR TITLE
fixes #95 - condition was only checking truthy values

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -323,7 +323,7 @@ const setVolume = (volume) => {
 }
 
 const checkVolume = (ytShorts) => {
-  if(localStorage.getItem("yt-player-volume") !== null && JSON.parse(localStorage.getItem("yt-player-volume"))["data"]["volume"]){
+  if(localStorage.getItem("yt-player-volume") !== null && JSON.parse(localStorage.getItem("yt-player-volume"))["data"]["volume"] !== undefined ){
     actualVolume = JSON.parse(localStorage.getItem("yt-player-volume"))["data"]["volume"];
     ytShorts.volume = actualVolume;
   }else{


### PR DESCRIPTION
Found the issue, a classic case of just checking for a truthy value rather than being explicit.

0 == false, so the condition that checked if the volume existed wouldnt register 0 as a proper value, and would instead use youtubes value.

fixes #95 