### PR TITLE
Enable clickable link in YouTube Shorts comments - #96

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -115,7 +115,7 @@ function lowPriorityInterval()
   if ( window.location.toString().indexOf("youtube.com/shorts/") < 0 ) return
 
   if ( isCommentsPanelOpen() )
-    handleReturnLinksToComments()
+    handleReturnLinksToComments( options[ "show_links_in_comments" ] )
 }
 
 function resetIntervals()

--- a/src/content.ts
+++ b/src/content.ts
@@ -2,7 +2,7 @@ import BROWSER from "./background/browser"
 import { checkVolume } from "./lib/VolumeSlider"
 import { DEFAULT_STATE } from "./lib/declarations"
 import { StateObject } from "./lib/definitions"
-import { getCurrentId, getLikeCount, getVideo } from "./lib/getters"
+import { getCurrentId, getLikeCount, getVideo, isCommentsPanelOpen } from "./lib/getters"
 import { handleKeyEvent } from "./lib/handleKeyEvent"
 import { retrieveFeaturesFromStorage, retrieveKeybindsFromStorage, retrieveOptionsFromStorage, retrieveSettingsFromStorage } from "./lib/retrieveFromStorage"
 import { handleSkipShortsWithLowLikes, shouldSkipShort } from "./lib/SkipShortsWithLowLikes"
@@ -14,6 +14,7 @@ import { hasVideoEnded, isVideoPlaying } from "./lib/VideoState"
 import { handleAutoplay, handleEnableAutoplay } from "./lib/Autoplay"
 import { handleAutomaticallyOpenComments } from "./lib/AutomaticallyOpenComments"
 import { handleProgressBarNotAppearing } from "./lib/ProgressBar"
+import { handleReturnLinksToComments } from "./lib/ReturnLinksToComments"
 
 /**
  * content.ts
@@ -56,8 +57,9 @@ BROWSER.runtime.onMessage.addListener( ( req, sender, sendResponse ) => {
 
 document.addEventListener( "keydown", e => handleKeyEvent( e, features, keybinds, settings, options, state ) )
 
-var main_interval    = setInterval( main, 100 )
-var volume_interval  = setInterval( volumeIntervalCallback, 10 )
+var high_priority_interval = setInterval( highPriorityInterval,  10 )
+var mid_priority_interval  = setInterval( midPriorityInterval,  100 )
+var low_priority_interval  = setInterval( lowPriorityInterval, 1000 )
 
 function main() {
   if ( window.location.toString().indexOf("youtube.com/shorts/") < 0 ) return
@@ -88,17 +90,42 @@ function main() {
   handleInjectionChecks( state, settings, features )
 }
 
-function volumeIntervalCallback()
+/**
+ * Reserve this specifically for things that require instantaneous response
+ */
+function highPriorityInterval()
 {
   if ( window.location.toString().indexOf("youtube.com/shorts/") < 0 ) return
   if ( getVideo() ) checkVolume( settings, features[ "Volume Slider" ] )
 }
 
+/**
+ * Most actions should go here
+ */
+function midPriorityInterval()
+{
+  main()
+}
+
+/**
+ * Put expensive, unimportant actions in here.
+ */
+function lowPriorityInterval()
+{
+  if ( window.location.toString().indexOf("youtube.com/shorts/") < 0 ) return
+
+  if ( isCommentsPanelOpen() )
+    handleReturnLinksToComments()
+}
+
 function resetIntervals()
 {
-  clearInterval( volume_interval )
-  volume_interval = setInterval( volumeIntervalCallback, 10 )
+  clearInterval( high_priority_interval )
+  high_priority_interval = setInterval( highPriorityInterval, 10 )
   
-  clearInterval( main_interval )
-  main_interval = setInterval( main, 100 )
+  clearInterval( mid_priority_interval )
+  mid_priority_interval = setInterval( midPriorityInterval, 100 )
+
+  clearInterval( low_priority_interval )
+  low_priority_interval = setInterval( lowPriorityInterval, 1000 )
 }

--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -128,3 +128,8 @@ input:checked + .autoplay-slider:before {
   color: white;
   z-index: 50;
 }
+
+.betterYT--comment-link
+{
+  color: rgb(152, 226, 239);
+}

--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -131,5 +131,6 @@ input:checked + .autoplay-slider:before {
 
 .betterYT--comment-link
 {
+  display: inline;
   color: rgb(152, 226, 239);
 }

--- a/src/lib/AutomaticallyOpenComments.ts
+++ b/src/lib/AutomaticallyOpenComments.ts
@@ -1,5 +1,5 @@
 import { StateObject } from "./definitions";
-import { getCommentsButton, getCurrentId } from "./getters";
+import { getCommentsButton, getCurrentId, isCommentsPanelOpen } from "./getters";
 
 
 export function handleAutomaticallyOpenComments( state: StateObject, options: any )
@@ -28,11 +28,4 @@ function shouldOpenComments( state: StateObject, options: any )
   if ( isCommentsPanelOpen() )                  return false
 
   return true
-}
-
-function isCommentsPanelOpen()
-{
-  // return true if the selector finds an open panel
-  // if panel is unfound, then the short either hasnt loaded, or the panel is not open
-  return document.querySelector( `[ id="${getCurrentId()}" ] #watch-while-engagement-panel  [ visibility="ENGAGEMENT_PANEL_VISIBILITY_EXPANDED" ]` ) ?? false
 }

--- a/src/lib/ReturnLinksToComments.ts
+++ b/src/lib/ReturnLinksToComments.ts
@@ -1,4 +1,4 @@
-import { getComments, isCommentsPanelOpen } from "../lib/getters" 
+import { getComments } from "../lib/getters" 
 
 const prefixRegex = /((https?|ftp|www):\/\/)/
 const linkRegex   = /[^\s]+\.[^\s]{2,}/g
@@ -6,11 +6,11 @@ const linkRegex   = /[^\s]+\.[^\s]{2,}/g
 // todo - move to getters
 
 
-export function handleReturnLinksToComments()
+export function handleReturnLinksToComments( enabled: boolean )
 {
-	const comments = getComments()
+  if ( !enabled ) return
 
-  console.log( {comments} )
+	const comments = getComments()
 
   comments.forEach( comment => {
     if ( comment.getAttribute( "data-bys-checkedForLinks" ) === "true" ) return // dont check twice
@@ -21,8 +21,6 @@ export function handleReturnLinksToComments()
     comment.setAttribute( "data-bys-checkedForLinks", "true" )
     
     if ( links === null ) return
-
-    console.log( links )
     
     links.map( link => {
 			let href = link

--- a/src/lib/ReturnLinksToComments.ts
+++ b/src/lib/ReturnLinksToComments.ts
@@ -1,0 +1,41 @@
+import { getComments, isCommentsPanelOpen } from "../lib/getters" 
+
+const prefixRegex = /((https?|ftp|www):\/\/)/
+const linkRegex   = /[^\s]+\.[^\s]{2,}/g
+
+// todo - move to getters
+
+
+export function handleReturnLinksToComments()
+{
+	const comments = getComments()
+
+  console.log( {comments} )
+
+  comments.forEach( comment => {
+    if ( comment.getAttribute( "data-bys-checkedForLinks" ) === "true" ) return // dont check twice
+
+  	const content = comment.innerHTML
+  	const links = content.match( linkRegex )
+
+    comment.setAttribute( "data-bys-checkedForLinks", "true" )
+    
+    if ( links === null ) return
+
+    console.log( links )
+    
+    links.map( link => {
+			let href = link
+  	
+      // link will need prefix if it doesnt already have one
+      if ( content.match( prefixRegex ) === null )
+      {
+        href = "http://" + link.slice(0)
+      }
+      
+      comment.innerHTML = content.replace( link, `<a class="betterYT--comment-link" href="${href}" target="_blank">${link}</a>` )
+		} )
+  
+  })
+  
+}

--- a/src/lib/declarations.ts
+++ b/src/lib/declarations.ts
@@ -40,12 +40,14 @@ export const DEFAULT_OPTIONS: DefaultsDictionary = {
   skip_threshold: 500,
   seek_amount: 5,
   automatically_open_comments: false,
+  show_links_in_comments: false,
 }
 export const OPTIONS_ORDER: DefaultsDictionary = [
   "seek_amount",
   "automatically_open_comments",
   "skip_enabled",
   "skip_threshold",
+  "show_links_in_comments",
 ]
 
 
@@ -72,6 +74,11 @@ export const OPTION_DICTIONARY: OptionsDictionary = {
   automatically_open_comments:
   {
     desc: "Open comments on new shorts automatically?",
+    type: "checkbox",
+  },
+  show_links_in_comments:
+  {
+    desc: "Make links in the comments clickable?",
     type: "checkbox",
   }
 }

--- a/src/lib/getters.ts
+++ b/src/lib/getters.ts
@@ -114,3 +114,18 @@ export function getCommentsButton()
   ) as HTMLElement
   
 }
+
+export function getComments() {
+  // make sure this works
+  // [id="0"] ytd-comment-thread-renderer #comment #body #main #comment-content #content #content-text .style-scope.yt-formatted-string
+  return (
+    [ ...document.querySelectorAll( `[ id="${getCurrentId()}" ] ytd-comment-thread-renderer #comment #body #main #comment-content #content #content-text span.style-scope.yt-formatted-string` ) ]
+  )
+}
+  
+export function isCommentsPanelOpen()
+{
+  // return true if the selector finds an open panel
+  // if panel is unfound, then the short either hasnt loaded, or the panel is not open
+  return document.querySelector( `[ id="${getCurrentId()}" ] #watch-while-engagement-panel  [ visibility="ENGAGEMENT_PANEL_VISIBILITY_EXPANDED" ]` ) ?? false
+}


### PR DESCRIPTION
Changed the names of the intervals to be a bit more generic.
Added a new "low priority" interval that fires every second.
That interval currently handles the new "returning links" implementation.

Essentially, just replaces any text-based link with an `<a>` tag link that can be clicked.

Handles HTTP, FTP and WWW links, as well as those without (eg: "youtube.com", it'll just affix "http://" to the start)

A link is selected via regex, specifically, this: `/[^\s]+\.[^\s]{2,}/g`
Any collection of non-space characters that is contiguous with a period, and then has two or more non-space characters thereafter is considered a link.

There will be issues with this; if a comment has, for example "this isn.ta link", it'll register `http://isn.ta` as a link. These can be ignored mind you.

(this will likely only work with first level comments, not replies)

For #96 