### PR TITLE
add: Brazilian Portuguese million multiplier

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -610,6 +610,7 @@ function convertLocaleNumber( string )
 
 	  // Portuguese
 	  "mil": 1_000,
+	  "mi": 1_000_000,
 
 	  // Spanish
 	  "mil": 1_000,


### PR DESCRIPTION
I was having some trouble with auto skip because the million multiplier for Brazilian Portuguese language was not being validated. Here's the fix :blush: 