### PR TITLE
Firefox Dev Setup Workaround

### DIFF
--- a/firefox_manifest_gen.py
+++ b/firefox_manifest_gen.py
@@ -2,34 +2,10 @@ import subprocess
 
 FILES_TO_WATCH = "ts,tsx,scss"
 
-RELATIVE_PATH_TO_CHROME_MANIFEST  = "./dist/manifest.json"
-RELATIVE_PATH_TO_FIREFOX_MANIFEST = "./dist/firefox_manifest.json"
-
-REPLACED_LINES = {
-  "service_worker": '\t\t"scripts": ["service-worker-loader.js"]',
-}
-
-def create_firefox_manifest():
-  with open( RELATIVE_PATH_TO_FIREFOX_MANIFEST, "w" ) as firefox_manifest:
-    
-    with open( RELATIVE_PATH_TO_CHROME_MANIFEST, "r" ) as chrome_manifest:
-
-      lines = [line.rstrip() for line in chrome_manifest]
-      
-      for line in lines:
-        for key in REPLACED_LINES.keys():
-          if key in line:
-            line = REPLACED_LINES.get( key )
-        
-        firefox_manifest.write( line + "\n" )    
-        
-
 def main():
-  create_firefox_manifest()
   try:
-    subprocess.check_call( f"nodemon -e {FILES_TO_WATCH} --exec npm run build", shell=True )
+    subprocess.check_call( f"nodemon -e {FILES_TO_WATCH} --exec python3 firefox_nodemon.py", shell=True )
   except:
     print( "An error occured with the nodemon command." ) 
-
 
 main()

--- a/firefox_manifest_gen.py
+++ b/firefox_manifest_gen.py
@@ -1,0 +1,35 @@
+import subprocess
+
+FILES_TO_WATCH = "ts,tsx,scss"
+
+RELATIVE_PATH_TO_CHROME_MANIFEST  = "./dist/manifest.json"
+RELATIVE_PATH_TO_FIREFOX_MANIFEST = "./dist/firefox_manifest.json"
+
+REPLACED_LINES = {
+  "service_worker": '\t\t"scripts": ["service-worker-loader.js"]',
+}
+
+def create_firefox_manifest():
+  with open( RELATIVE_PATH_TO_FIREFOX_MANIFEST, "w" ) as firefox_manifest:
+    
+    with open( RELATIVE_PATH_TO_CHROME_MANIFEST, "r" ) as chrome_manifest:
+
+      lines = [line.rstrip() for line in chrome_manifest]
+      
+      for line in lines:
+        for key in REPLACED_LINES.keys():
+          if key in line:
+            line = REPLACED_LINES.get( key )
+        
+        firefox_manifest.write( line + "\n" )    
+        
+
+def main():
+  create_firefox_manifest()
+  try:
+    subprocess.check_call( f"nodemon -e {FILES_TO_WATCH} --exec npm run build", shell=True )
+  except:
+    print( "An error occured with the nodemon command." ) 
+
+
+main()

--- a/firefox_nodemon.py
+++ b/firefox_nodemon.py
@@ -1,0 +1,31 @@
+import subprocess
+
+RELATIVE_PATH_TO_MANIFEST  = "./dist/manifest.json"
+# RELATIVE_PATH_TO_FIREFOX_MANIFEST = "./dist/firefox_manifest.json" # doesnt seem to like it not being called manifest.json
+
+REPLACED_LINES = {
+  "service_worker": '\t\t"scripts": ["service-worker-loader.js"],',
+}
+
+def create_firefox_manifest():
+  with open( RELATIVE_PATH_TO_MANIFEST, "r" ) as chrome_manifest:
+    lines     = [line.rstrip() for line in chrome_manifest]
+    new_lines = []
+    
+    for line in lines:
+      for key in REPLACED_LINES.keys():
+        if key in line:
+          line = REPLACED_LINES.get( key )
+      
+        new_lines.append( line + "\n" ) 
+  
+  with open( RELATIVE_PATH_TO_MANIFEST, "w" ) as firefox_manifest:
+    firefox_manifest.writelines( new_lines )    
+        
+
+def main():
+  process = subprocess.Popen( f"npm run build", shell=True )
+  process.wait()
+  create_firefox_manifest()
+  
+main()

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "concurrently --kill-others \"sass --watch src/css\" \"vite\"",
     "build": "sass src/css && tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    
+    "ff-dev": "python3 firefox_manifest_gen.py"
   },
   "dependencies": {
     "react": "^18.0.0",


### PR DESCRIPTION
I'm trying to figure out a workaround for automatically refreshing/updating the v3 dev version of bys for #101 

For whatever reason, the extension on firefox will only work for me if its named `manifest.json`

So far, `npm run ff-dev` will, with a small delay, allow you to see changes by simply reopening the popup.
I use python for my shell scripting, so you'll need to make sure you have it installed. Havent tried the python3 command (as opposed to just python) on windows atm, but hopefully it works

As for the content script, you'll need to head to the temporary extension page and reload the extension manually it seems.

<img width="645" alt="image" src="https://github.com/ynshung/better-yt-shorts/assets/74009107/72c3681b-e242-4af0-8df9-7fd7c529c5e6">