### PR TITLE
Fixes for Popup Font Size

### DIFF
--- a/src/css/globals.scss
+++ b/src/css/globals.scss
@@ -13,6 +13,8 @@
   --call-to-action-color: #3ea6ff;
 
   --max-height: 600px; // of the chrome popup 
+
+  font-size: 16px;
 }
 
 @media (prefers-color-scheme: dark) 

--- a/src/css/popup.scss
+++ b/src/css/popup.scss
@@ -86,6 +86,7 @@ tr:not(:first-child):hover {
 
 .version {
   color: var(--bg-primary-hover-color);
+  font-size: 0.8rem;
 }
 
 .separation-line {
@@ -731,7 +732,9 @@ input:checked + .autoplay-slider:before {
 {
   color: var(--text-secondary-color);
   text-align: center;
-  padding-bottom: .5rem;
+  padding: .4rem 0;
+  font-size: .8rem;
+  word-wrap: balance;
 }
 
 #page-indicator {


### PR DESCRIPTION
Not exactly sure why the font size was incorrect, but firefox seems to have a larger default font size than chrome?
Fixed by explicitly setting the size

Also should note that the word-wrap property in CSS is experimental and not currently used in firefox it seems. (which would explain the options page layout being a bit off)