### PR TITLE
Fixes #133 - Fixed Like Count Regex

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,7 +10,7 @@ export function convertLocaleNumber( string: string ): number | null
 {
   if ( typeof string !== "string" ) return null
   
-  const regex = /^([0-9\.,]+)\s?(\p{L}+)/ui;
+  const regex = /^([0-9\.,]+)\s?(\p{L}+)?/ui;
   const matches = string.match(regex)
 
 	if (!matches) {


### PR DESCRIPTION
There was an issue where the regex wouldnt match counts that didn't have modifiers. 

For such counts, it'd return 0

for #133
