### PR TITLE
Adjust autoplay implementation

### DIFF
--- a/src/lib/Autoplay.ts
+++ b/src/lib/Autoplay.ts
@@ -16,8 +16,8 @@ export function handleEnableAutoplay( settings: any, enabled: boolean )
   const ytShorts = getVideo()
   if ( ytShorts === null ) return false
 
-  if ( settings.autoplay ) ytShorts.loop = !enabled
-  else ytShorts.loop = true
+  // if ( settings.autoplay ) ytShorts.loop = !enabled
+  // else ytShorts.loop = true
 }
 
 export function createAutoplaySwitch( settings: any, enabled: boolean )

--- a/src/lib/VideoState.ts
+++ b/src/lib/VideoState.ts
@@ -13,7 +13,7 @@ export function hasVideoEnded()
   const ytShorts = getVideo()
   if ( ytShorts === null ) return false
 
-  return ytShorts.currentTime >= ytShorts.duration - 0.11
+  return ytShorts.currentTime >= ytShorts.duration - 0.25
 }
 
 export function skipShort()


### PR DESCRIPTION
The autoplay won't be affecting the loop functionality anymore, at the cost of possible skipping of some milliseconds at the end of the shorts, will be leaving it this way for now
It would be great if there are some better way to check if the video ended or any other way to stop the video from replaying before skipping to next short
Further info see the following issue, closes #131 
