### PR TITLE
Removed view counter functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Control your YouTube shorts just like a normal YouTube video! Features include p
 - Click the speed button to revert to normal speed or toggle between different speeds
 - Toggle to auto skip short when current one ends
 - Control volume with the **volume slider** or with - and =, mute audio with M
-- View counter and upload date above video title
 - **Customizable** keybinds
 
 Extra features:
@@ -39,6 +38,7 @@ Extra features:
 - Hide overlay on shorts (title, channel, etc.)
 - Navigate to previous or next short without animation with W and S
 - Go to the next frame or previous frame with . and , while paused
+- Upload date above video title
 
 ### Screenshots
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -158,9 +158,6 @@
   "volumeSlider": {
     "message": "Volume Slider"
   },
-  "viewCounter": {
-    "message": "View Counter"
-  },
   "uploadDate": {
     "message": "Upload Date"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extName__",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "action": { "default_popup": "index.html" },
   "permissions": ["storage"],
 

--- a/src/lib/Info.ts
+++ b/src/lib/Info.ts
@@ -1,20 +1,11 @@
 import { isVideoPlaying } from "./VideoState";
-import {
-  getCurrentId,
-  getOverlayElement,
-  getUploadDate,
-  getViews,
-} from "./getters";
+import { getCurrentId, getOverlayElement, getUploadDate } from "./getters";
 
 export function setInfo(features: any) {
   const views_interval = setInterval(addInfo, 10);
 
   function addInfo() {
     const info = [];
-    if (features["viewCounter"]) {
-      const views = getViews().replace(/(\r\n|\n|\r)/gm, "");
-      if (views) info.push(views);
-    }
     if (features["uploadDate"]) {
       const uploadDate = getUploadDate().replace(/(\r\n|\n|\r)/gm, "");
       if (uploadDate) info.push(uploadDate);

--- a/src/lib/declarations.ts
+++ b/src/lib/declarations.ts
@@ -156,7 +156,6 @@ export const DEFAULT_FEATURES = {
   playbackRate: true,
   volumeSlider: true,
   keybinds: true,
-  viewCounter: true,
   uploadDate: true,
 };
 
@@ -167,7 +166,6 @@ export const FEATURES_ORDER: DefaultsDictionary = [
   "playbackRate",
   "volumeSlider",
   "keybinds",
-  "viewCounter",
   "uploadDate",
 ];
 

--- a/src/lib/getters.ts
+++ b/src/lib/getters.ts
@@ -126,19 +126,9 @@ export function getOverlay() {
   ) as HTMLElement;
 }
 
-export function getViews() {
+export function getUploadDate() {
   return (
     document.querySelector("#factoids ytd-factoid-renderer:nth-child(2) div")
       ?.textContent ?? ""
-  );
-}
-
-export function getUploadDate() {
-  return (
-    (
-      document.querySelector(
-        "#factoids ytd-factoid-renderer:nth-child(3) div",
-      ) as HTMLElement
-    ).textContent ?? ""
   );
 }


### PR DESCRIPTION
Unfortunately an internal change from YouTube remove the amount of views in the `#factoids` section, bummer. It was good while it lasted. This change make sure that the selection section is correctly labelled as the upload date.

Closes #168 which removes changes from #140 & #164