### PR TITLE
fixes #177

### DIFF
--- a/src/lib/getters.ts
+++ b/src/lib/getters.ts
@@ -74,7 +74,7 @@ export function getTitle() {
 export function getVolumeContainer() {
   const id = getCurrentId();
   return document.querySelector(
-    `[id="${id}"]  > #player-container > div.player-controls.style-scope.ytd-reel-video-renderer > ytd-shorts-player-controls.style-scope.ytd-reel-video-renderer`,
+    `[id="${id}"] #player-container div.player-controls > ytd-shorts-player-controls.style-scope`,
   ) as HTMLElement;
 }
 


### PR DESCRIPTION
Changed selector for volume container.

Youtube mustve changed their html structure again, meaning the our slider was never added and the injection was marked as failing. Failing injection caused it to loop, continuing to add buttons over and over

#177 