### PR TITLE
Fix progress bar selector

### DIFF
--- a/src/lib/getters.ts
+++ b/src/lib/getters.ts
@@ -105,7 +105,9 @@ export function getVolumeSliderController() {
 }
 
 export function getProgressBarList() {
-  return getOverlayElement().querySelector("#progress-bar-line");
+  return document.querySelector(
+    `[id="${getCurrentId()}"] > div.short-video-container > #player-container > #progress-bar > ytd-progress-bar-line > #progress-bar-line`,
+  );
 }
 
 export function getMuteButton() {


### PR DESCRIPTION
Layout changes internally at YouTube causes the duplicating speed/timestamp bug to appear again