### PR TITLE
Resolves #87 - Add Option for Default Playback Rate

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -136,6 +136,9 @@
   "showVolumeHorizontally": {
     "message": "Show volume slider horizontally instead of vertically"
   },
+  "defaultPlaybackRate": {
+    "message": "Change the default playback rate when you first open the shorts page"
+  },
   "toggleFeatures": {
     "message": "Toggle Features"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -137,7 +137,7 @@
     "message": "Show volume slider horizontally instead of vertically"
   },
   "defaultPlaybackRate": {
-    "message": "Change the default playback rate when you first open the shorts page"
+    "message": "Default playback rate"
   },
   "toggleFeatures": {
     "message": "Toggle Features"

--- a/src/content.ts
+++ b/src/content.ts
@@ -65,6 +65,10 @@ retrieveKeybindsFromStorage((newBinds) => {
 });
 retrieveOptionsFromStorage((newOpts) => {
   options = newOpts;
+
+  // set the default playback rate here
+  if (typeof options["defaultPlaybackRate"] !== "number") return;
+  state.playbackRate = options["defaultPlaybackRate"];
 });
 retrieveSettingsFromStorage((newSettings) => {
   settings = newSettings;

--- a/src/lib/ActionElement.ts
+++ b/src/lib/ActionElement.ts
@@ -88,7 +88,9 @@ export function populateActionElement(
   createAutoplaySwitch(settings, features["autoplay"]);
 
   if (features["playbackRate"])
+  {
     ytShorts.playbackRate = state.playbackRate as number;
+  }
 
   setPlaybackRate(state);
   // injectedSuccess = setTimer( currTime || 0, Math.round(ytShorts.duration || 0))

--- a/src/lib/ActionElement.ts
+++ b/src/lib/ActionElement.ts
@@ -87,8 +87,7 @@ export function populateActionElement(
 
   createAutoplaySwitch(settings, features["autoplay"]);
 
-  if (features["playbackRate"])
-  {
+  if (features["playbackRate"]) {
     ytShorts.playbackRate = state.playbackRate as number;
   }
 

--- a/src/lib/declarations.ts
+++ b/src/lib/declarations.ts
@@ -53,6 +53,7 @@ export const DEFAULT_OPTIONS: PolyDictionary = {
   automaticallyOpenComments: false,
   hideShortsOverlay: false,
   showVolumeHorizontally: false,
+  defaultPlaybackRate: 1,
 };
 
 export const OPTIONS_ORDER: string[] = [
@@ -62,6 +63,7 @@ export const OPTIONS_ORDER: string[] = [
   "skipThreshold",
   "hideShortsOverlay",
   "showVolumeHorizontally",
+  "defaultPlaybackRate",
 ];
 
 export const OPTION_DICTIONARY: OptionsDictionary = {
@@ -92,6 +94,12 @@ export const OPTION_DICTIONARY: OptionsDictionary = {
   showVolumeHorizontally: {
     desc: local("showVolumeHorizontally"),
     type: "checkbox",
+  },
+  defaultPlaybackRate: {
+    desc: local("defaultPlaybackRate"),
+    type: "number",
+    min: 0.25,
+    max: 16,
   },
 };
 

--- a/src/lib/declarations.ts
+++ b/src/lib/declarations.ts
@@ -58,13 +58,13 @@ export const DEFAULT_OPTIONS: PolyDictionary = {
 };
 
 export const OPTIONS_ORDER: string[] = [
+  "defaultPlaybackRate",
   "seekAmount",
   "automaticallyOpenComments",
   "skipEnabled",
   "skipThreshold",
   "hideShortsOverlay",
   "showVolumeHorizontally",
-  "defaultPlaybackRate",
 ];
 
 export const OPTION_DICTIONARY: OptionsDictionary = {


### PR DESCRIPTION
New option to allow users to change the default playback rate when they first open the page.

This was requested a while ago in issue #87 