### PR TITLE
Avoid multiline splits of upload date

### DIFF
--- a/src/lib/getters.ts
+++ b/src/lib/getters.ts
@@ -134,7 +134,8 @@ export function getOverlay() {
 
 export function getUploadDate() {
   return (
-    document.querySelector("#factoids ytd-factoid-renderer:nth-child(2) div")
-      ?.textContent ?? ""
+    document
+      .querySelector("#factoids ytd-factoid-renderer:nth-child(2) div")
+      ?.getAttribute("aria-label") ?? ""
   );
 }


### PR DESCRIPTION
Hey there!

I'm not sure how it looks on other locales, but here a normal date looks like this: `21 oct. 2023`.

Scrolling through Shorts you will occasionally see videos where the upload date is split into multiple lines and glued together by the extension, but backwards: `2023 21 oct.`, which is quite a sore in the eye.

I'm not sure what would be the best solution here, but this seems to be both the easiest and most reliable one 🤔