### PR TITLE
fix of a broken hidden overlay

### DIFF
--- a/src/lib/getters.ts
+++ b/src/lib/getters.ts
@@ -132,7 +132,7 @@ export function getCommentsButton() {
 
 export function getOverlay() {
   return document.querySelector(
-    `[id="${getCurrentId()}"] #overlay ytd-reel-player-header-renderer`,
+    `[id="${getCurrentId()}"] #overlay reel-player-header-renderer`,
   ) as HTMLElement;
 }
 


### PR DESCRIPTION
Changed the name of the overlay tag to reel-player-header-renderer