### PR TITLE
Ignore key modifiers when handling keyboard events

### DIFF
--- a/src/lib/declarations.ts
+++ b/src/lib/declarations.ts
@@ -290,6 +290,16 @@ export const EXCLUDED_KEY_BINDS = [
   "AltRight",
 ];
 
+/**
+ * The set of modifers that will be checked to determine if a given key should
+ * be ignored when handling key events.
+ *
+ * Note that these correspond to `KeyboardEvent.key` values since `KeyboardEvent.getModifierState`
+ * does not accept `KeyboardEvent.code` values.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState}
+ */
+export const EXCLUDED_KEY_MODIFIERS = ["Alt", "Control", "Meta", "Shift"];
+
 export const DEFAULT_PRESSED_KEY = local("pressAKey");
 export const DISABLED_BIND_STRING = local("disabled");
 

--- a/src/lib/handleKeyEvent.ts
+++ b/src/lib/handleKeyEvent.ts
@@ -1,7 +1,10 @@
 import { tryToggleFullscreen } from "./HandleFullscreen";
 import { goToNextShort, goToPreviousShort, restartShort } from "./VideoState";
 import { setVolume } from "./VolumeSlider";
-import { VOLUME_INCREMENT_AMOUNT } from "./declarations";
+import {
+  EXCLUDED_KEY_MODIFIERS,
+  VOLUME_INCREMENT_AMOUNT,
+} from "./declarations";
 import {
   BooleanDictionary,
   StateObject,
@@ -32,6 +35,11 @@ export function handleKeyEvent(
 
   const ytShorts = getVideo();
   if (!ytShorts) return;
+
+  const modifierPressed = EXCLUDED_KEY_MODIFIERS.some((modifier) =>
+    e.getModifierState(modifier),
+  );
+  if (modifierPressed) return;
 
   const key = e.code;
   const keyAlt = e.key.toLowerCase(); // for legacy keybinds


### PR DESCRIPTION
This branch adds a set of modifiers that are be ignored when handling keyboard events to avoid accidentally activating better-yt-shorts shorcuts when trying to use system shortcuts.

For example, I noticed that pressing `cmd+f`/`ctrl+f` to search for text on the page (e.g. comments on a yt short) also activates the full screen shortcut if you're using the default keybind.